### PR TITLE
fixed bug when in 1280px slider shows one element instead of three

### DIFF
--- a/app/[locale]/components/Home/Partners/Slider.jsx
+++ b/app/[locale]/components/Home/Partners/Slider.jsx
@@ -9,16 +9,15 @@ import styles from './partners.module.scss';
 
 import Image from "next/image";
 
+const getSlidesPerView = () => {
+  return window.innerWidth > 1279 ? 3 : 1;
+}
 
 const Slider = ({ data }) => {
   const [isReady, setIsReady] = useState(false);
-  const [slidesPerView, setSlidesPerView] = useState(1);
+  const [slidesPerView, setSlidesPerView] = useState(getSlidesPerView());
 
   useEffect(() => {
-    const getSlidesPerView = () => {
-      return window.innerWidth > 1279 ? 3 : 1;
-    }
-  
     const handleResize = () => {
       const newSlidesPerView = getSlidesPerView();
   


### PR DESCRIPTION
When the screen first loaded, the slider showed one slider, after reboot it showed three. Fixed. The slider works fine from the beginning.